### PR TITLE
Target a version 5.1.0 release candidate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.1.0.rc1 / 2015-05-04
+
+* [ENHANCEMENT] Re-roll
+
 ## 5.0.0 / 2015-03-31
 
 * [ENHANCEMENT] Re-roll

--- a/fair_dice_roll.gemspec
+++ b/fair_dice_roll.gemspec
@@ -2,7 +2,7 @@
 
 Gem::Specification.new do |spec|
   spec.name    = "fair_dice_roll"
-  spec.version = "5.0.0"
+  spec.version = "5.1.0.rc1"
 
   spec.author      = "Steve Richert"
   spec.email       = "steve.richert@gmail.com"


### PR DESCRIPTION
![re-roll](https://cloud.githubusercontent.com/assets/34264/7459875/28e642c2-f26d-11e4-87ec-9e2b8497e985.jpg)

A re-roll occurred but produced the same number as the previous major version. Such is randomness. As this is the first minor version bump, a release candidate is in order to ensure backwards compatibility in the wild.